### PR TITLE
Disable modal close on overlay click

### DIFF
--- a/src/components/CompareModal.tsx
+++ b/src/components/CompareModal.tsx
@@ -67,7 +67,7 @@ export function CompareModal({
   const canCompare = leftSelection && rightSelection && leftSelection !== rightSelection;
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay">
       <div className="compare-modal" onClick={(e) => e.stopPropagation()}>
         <h3>Compare Timetables</h3>
         <p className="compare-modal-desc">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -26,7 +26,7 @@ export function Modal({
   const confirmClass = confirmVariant === 'primary' ? 'modal-confirm-primary' : 'modal-confirm';
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay">
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <h3>{title}</h3>
         {children}

--- a/src/components/OptionsPanel.tsx
+++ b/src/components/OptionsPanel.tsx
@@ -226,7 +226,7 @@ export function OptionsPanel({
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay">
       <div className="options-panel" onClick={(e) => e.stopPropagation()}>
         <div className="options-header">
           <h3>Options</h3>

--- a/src/components/PrivacyNoticeModal.tsx
+++ b/src/components/PrivacyNoticeModal.tsx
@@ -6,7 +6,7 @@ interface PrivacyNoticeModalProps {
 
 export function PrivacyNoticeModal({ onClose }: PrivacyNoticeModalProps) {
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay">
       <div className="privacy-notice-modal" onClick={(e) => e.stopPropagation()}>
         <div className="privacy-notice-header">
           <Shield size={32} className="privacy-notice-icon" />

--- a/src/components/ShareWelcomeModal.tsx
+++ b/src/components/ShareWelcomeModal.tsx
@@ -6,7 +6,7 @@ interface ShareWelcomeModalProps {
 
 export function ShareWelcomeModal({ onClose }: ShareWelcomeModalProps) {
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay">
       <div className="share-welcome-modal" onClick={(e) => e.stopPropagation()}>
         <div className="share-welcome-header">
           <Share2 size={32} className="share-welcome-icon" />

--- a/src/pages/HelpPage.tsx
+++ b/src/pages/HelpPage.tsx
@@ -78,7 +78,7 @@ function HelpPage({ onUploadClick, onPrivacyClick }: HelpPageProps) {
       </ol>
 
       {modalImage && (
-        <div className="image-modal-overlay" onClick={() => setModalImage(null)}>
+        <div className="image-modal-overlay">
           <div className="image-modal" onClick={(e) => e.stopPropagation()}>
             <button className="image-modal-close" onClick={() => setModalImage(null)}>
               <X size={24} />


### PR DESCRIPTION
## Summary
- Remove onClick handlers from modal overlay divs
- Modals now only close via action buttons or close buttons

Fixes #2

## Test plan
- [x] Open each modal type and click outside - should not close
- [x] Close modals using Cancel/Close buttons - should work
- [x] Close modals using action buttons - should work