### PR TITLE
fix: Cap compare filter limits

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.1.2 (18 Dec 2025)
+- Cap travel wait time at 2 hours
+- Cap dinner end time at 9pm
+
 ## v1.1.1 (18 Dec 2025)
 - Disable modal close on overlay click
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/CompareFilters.tsx
+++ b/src/components/CompareFilters.tsx
@@ -166,8 +166,6 @@ export function CompareFilters({
                 <option value={60}>1 hour</option>
                 <option value={90}>1.5 hours</option>
                 <option value={120}>2 hours</option>
-                <option value={180}>3 hours</option>
-                <option value={240}>4 hours</option>
               </select>
             </label>
           </div>
@@ -212,8 +210,8 @@ export function CompareFilters({
               tooltip="Set the dinner time window"
               startValue={mealConfig.dinnerStart}
               endValue={mealConfig.dinnerEnd}
-              startOptions={Array.from({ length: 8 }, (_, i) => i + 15)}
-              endOptions={Array.from({ length: 8 }, (_, i) => i + 17)}
+              startOptions={Array.from({ length: 6 }, (_, i) => i + 15)}
+              endOptions={Array.from({ length: 5 }, (_, i) => i + 17)}
               onStartChange={(v) => onMealConfigChange({ dinnerStart: v })}
               onEndChange={(v) => onMealConfigChange({ dinnerEnd: v })}
             />


### PR DESCRIPTION
## Summary
- Cap travel wait time at 2 hours (removed 3h/4h options)
- Cap dinner end time at 9pm (was 12am)

## Test plan
- [ ] Open Compare mode, select Travel Together, verify max wait option is 2 hours
- [ ] Select Eat Together, verify dinner end time max is 9pm