### PR TITLE
fix: Use lazy initializer for isMobile state

### DIFF
--- a/src/components/CompareFilters.tsx
+++ b/src/components/CompareFilters.tsx
@@ -237,13 +237,13 @@ export function CompareFilters({
 }: CompareFiltersProps) {
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [showConfigModal, setShowConfigModal] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(
+    () => window.matchMedia(MOBILE_BREAKPOINT).matches
+  );
 
-  // Detect mobile viewport
+  // Subscribe to viewport changes
   useEffect(() => {
     const mediaQuery = window.matchMedia(MOBILE_BREAKPOINT);
-    setIsMobile(mediaQuery.matches);
-
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mediaQuery.addEventListener('change', handler);
     return () => mediaQuery.removeEventListener('change', handler);


### PR DESCRIPTION
## Summary
- Fix ESLint `react-hooks/set-state-in-effect` error in CompareFilters.tsx
- Use lazy initializer for `useState` instead of synchronous `setState` in effect
- Effect now only subscribes to media query changes

## Test plan
- [ ] Run `npx eslint src/components/CompareFilters.tsx` - no errors
- [ ] Verify mobile detection still works correctly