### PR TITLE
fix: Add custom scrollbar to Privacy modal

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**v1.3.5 (19 Dec 2025)**
+- Add custom scrollbar styling to Privacy & Security modal
+
 **v1.3.4 (19 Dec 2025)**
 - Fix ESLint set-state-in-effect error in CompareFilters
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/PrivacyNoticeModal.module.scss
+++ b/src/components/PrivacyNoticeModal.module.scss
@@ -48,6 +48,7 @@
   overflow-y: auto;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
   animation: modalSlideIn 0.2s ease-out;
+  @include custom-scrollbar;
 }
 
 .header {


### PR DESCRIPTION
## Summary
- Apply the thin, light/dark aware `custom-scrollbar` mixin to the Privacy & Security modal

Closes #29

## Test plan
- [ ] Open the Privacy & Security modal
- [ ] Scroll the content and verify the scrollbar matches the app's styling
- [ ] Test in both light and dark mode