### PR TITLE
fix: Replace hardcoded #ccc with CSS variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**v1.5.6 (21 Dec 2025)**
+- Replace hardcoded #ccc with CSS variable for inactive course filter buttons
+
 **v1.5.5 (21 Dec 2025)**
 - Update README with current features, correct deploy instructions, and SCSS tech stack
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.5.5",
+  "version": "1.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/FilterSection.tsx
+++ b/src/components/FilterSection.tsx
@@ -63,7 +63,7 @@ export const FilterSection = memo(function FilterSection({
           backgroundColor:
             selectedCourses.has(course) || selectedCourses.size === 0
               ? courseColorMap.get(course)
-              : '#ccc',
+              : 'var(--color-btn-inactive-bg)',
           opacity: selectedCourses.size === 0 || selectedCourses.has(course) ? 1 : 0.5,
         }}
         onClick={() => onToggleCourse(course)}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -23,6 +23,7 @@
   --color-bg-hover: rgba(0, 0, 0, 0.12);
   --color-input-bg: #fff;
   --color-select-bg: #fff;
+  --color-btn-inactive-bg: #ccc;
 
   // Border colors
   --color-border: rgba(0, 0, 0, 0.15);
@@ -131,6 +132,7 @@ html.dark {
   --color-bg-hover: rgba(255, 255, 255, 0.12);
   --color-input-bg: rgba(255, 255, 255, 0.1);
   --color-select-bg: #3a3a3a;
+  --color-btn-inactive-bg: #555;
 
   --color-border: rgba(255, 255, 255, 0.15);
   --color-border-light: rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Summary
- Add `--color-btn-inactive-bg` CSS variable to `_variables.scss` (light: `#ccc`, dark: `#555`)
- Replace hardcoded `#ccc` in `FilterSection.tsx` with the new variable

Closes #69

## Test plan
- [ ] Load app in light mode, filter courses, verify inactive buttons show grey background
- [ ] Toggle to dark mode, verify inactive buttons use appropriate dark theme color