### PR TITLE
v1.5.13: Fix course code extraction to show full codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**v1.5.13 (25 Dec 2025)**
+- Fix existing contributions display to show full course codes (e.g., QUT001A not just QUT001)
+- Improve display: show abbreviated codes in collapsed state, full names when expanded
+
 **v1.5.12 (25 Dec 2025)**
 - Show existing contributions on Contribute page to prevent duplicate submissions
 - Remove telegram handle field from contribution form (privacy)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.5.12",
+  "version": "1.5.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/ContributePage/ContributePage.module.scss
+++ b/src/pages/ContributePage/ContributePage.module.scss
@@ -65,12 +65,25 @@
 
 .existingList {
   margin: 0.5rem 0 0;
-  padding: 0.75rem;
+  padding: 0.75rem 0.75rem 0.75rem 1.5rem;
   font-size: 0.8125rem;
   color: var(--color-text-secondary);
   background-color: var(--color-bg-secondary);
   border-radius: 6px;
-  line-height: 1.5;
+  line-height: 1.6;
+  list-style: disc;
+
+  li {
+    margin-bottom: 0.25rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  strong {
+    color: var(--color-text-primary);
+  }
 }
 
 .form {

--- a/src/pages/ContributePage/ContributePage.tsx
+++ b/src/pages/ContributePage/ContributePage.tsx
@@ -6,6 +6,11 @@ import { submitSchedule } from '../../firebase';
 import { FileUploadZone } from './FileUploadZone';
 import styles from './ContributePage.module.scss';
 
+interface CourseInfo {
+  code: string;
+  name: string;
+}
+
 export function ContributePage() {
   const [courseName, setCourseName] = useState('');
   const [notes, setNotes] = useState('');
@@ -13,15 +18,15 @@ export function ContributePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submissionId, setSubmissionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [existingCourses, setExistingCourses] = useState<string[]>([]);
+  const [existingCourses, setExistingCourses] = useState<CourseInfo[]>([]);
   const [showExisting, setShowExisting] = useState(false);
 
   useEffect(() => {
     fetch('/api/contributions')
       .then((res) => res.json())
       .then((data) => {
-        if (data.success && data.courseCodes) {
-          setExistingCourses(data.courseCodes);
+        if (data.success && data.courses) {
+          setExistingCourses(data.courses);
         }
       })
       .catch(() => {
@@ -91,13 +96,27 @@ export function ContributePage() {
             className={styles.existingToggle}
             onClick={() => setShowExisting(!showExisting)}
           >
-            See existing contributions
-            {showExisting ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+            {showExisting ? (
+              <>
+                Hide existing contributions
+                <ChevronUp size={16} />
+              </>
+            ) : (
+              <>
+                Existing contributions: {existingCourses.map((c) => c.code).join(', ')}...
+                <ChevronDown size={16} />
+              </>
+            )}
           </button>
           {showExisting && (
-            <p className={styles.existingList}>
-              Contributions already exist for: {existingCourses.join(', ')}
-            </p>
+            <ul className={styles.existingList}>
+              {existingCourses.map((course) => (
+                <li key={course.code}>
+                  <strong>{course.code}</strong>
+                  {course.name && ` - ${course.name}`}
+                </li>
+              ))}
+            </ul>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Fix course code extraction to capture full codes (e.g., `QUT001A` instead of just `QUT001`)
- Changed from regex-based extraction to simple split by " - " separator
- Collapsed state: Shows abbreviated codes like "Existing contributions: QUT001A, QUB511..."
- Expanded state: Shows full list with course names

## Test plan
- [ ] Visit /contribute page
- [ ] Verify course codes show full format (e.g., QUT001A not QUT001)
- [ ] Click to expand and verify full course names are shown