### PR TITLE
v1.5.14: Simplify existing contributions display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**v1.5.14 (25 Dec 2025)**
+- Simplify existing contributions: show full course titles as a plain list
+
 **v1.5.13 (25 Dec 2025)**
 - Fix existing contributions display to show full course codes (e.g., QUT001A not just QUT001)
 - Improve display: show abbreviated codes in collapsed state, full names when expanded

--- a/api/contributions.ts
+++ b/api/contributions.ts
@@ -4,43 +4,9 @@ interface GitHubIssue {
   title: string;
 }
 
-interface CourseInfo {
-  code: string;
-  name: string;
-}
-
-/**
- * Extract course info from issue title.
- * Titles are formatted: "[Upgrading Course] QUB511 - Biodiversity and Environmental Biology"
- * Returns { code: "QUB511", name: "Biodiversity and Environmental Biology" }
- */
-function extractCourseInfo(title: string): CourseInfo | null {
-  // Remove the "[Upgrading Course] " prefix
-  const prefix = '[Upgrading Course] ';
-  if (!title.startsWith(prefix)) {
-    return null;
-  }
-
-  const remainder = title.slice(prefix.length).trim();
-
-  // Split by " - " to get code and name
-  const dashIndex = remainder.indexOf(' - ');
-  if (dashIndex > 0) {
-    return {
-      code: remainder.slice(0, dashIndex).trim(),
-      name: remainder.slice(dashIndex + 3).trim(),
-    };
-  }
-
-  // No dash separator - use entire remainder as code
-  return {
-    code: remainder,
-    name: '',
-  };
-}
+const PREFIX = '[Upgrading Course] ';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  // Only allow GET
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
@@ -74,17 +40,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const issues: GitHubIssue[] = await response.json();
 
-    // Extract course info and dedupe by code
-    const courseMap = new Map<string, CourseInfo>();
-    for (const issue of issues) {
-      const info = extractCourseInfo(issue.title);
-      if (info && !courseMap.has(info.code)) {
-        courseMap.set(info.code, info);
-      }
-    }
-
-    // Sort by code and return as array
-    const courses = [...courseMap.values()].sort((a, b) => a.code.localeCompare(b.code));
+    // Extract course titles (strip prefix), dedupe, sort
+    const courses = [
+      ...new Set(
+        issues
+          .map((issue) => issue.title)
+          .filter((title) => title.startsWith(PREFIX))
+          .map((title) => title.slice(PREFIX.length).trim())
+      ),
+    ].sort();
 
     return res.status(200).json({
       success: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.5.13",
+  "version": "1.5.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/ContributePage/ContributePage.module.scss
+++ b/src/pages/ContributePage/ContributePage.module.scss
@@ -46,25 +46,21 @@
   margin-bottom: 1.5rem;
 }
 
-.existingToggle {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0;
-  border: none;
-  background: none;
+.existingLabel {
+  margin: 0 0 0.25rem;
   font-size: 0.875rem;
-  color: var(--color-primary);
-  cursor: pointer;
-  transition: color 0.2s;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
 
-  &:hover {
-    color: var(--color-primary-hover);
-  }
+.existingHint {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
 }
 
 .existingList {
-  margin: 0.5rem 0 0;
+  margin: 0;
   padding: 0.75rem 0.75rem 0.75rem 1.5rem;
   font-size: 0.8125rem;
   color: var(--color-text-secondary);
@@ -79,10 +75,6 @@
     &:last-child {
       margin-bottom: 0;
     }
-  }
-
-  strong {
-    color: var(--color-text-primary);
   }
 }
 

--- a/src/pages/ContributePage/ContributePage.tsx
+++ b/src/pages/ContributePage/ContributePage.tsx
@@ -1,15 +1,10 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { ArrowLeft, Send, CheckCircle, ChevronDown, ChevronUp } from 'lucide-react';
+import { ArrowLeft, Send, CheckCircle } from 'lucide-react';
 
 import { submitSchedule } from '../../firebase';
 import { FileUploadZone } from './FileUploadZone';
 import styles from './ContributePage.module.scss';
-
-interface CourseInfo {
-  code: string;
-  name: string;
-}
 
 export function ContributePage() {
   const [courseName, setCourseName] = useState('');
@@ -18,8 +13,7 @@ export function ContributePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submissionId, setSubmissionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [existingCourses, setExistingCourses] = useState<CourseInfo[]>([]);
-  const [showExisting, setShowExisting] = useState(false);
+  const [existingCourses, setExistingCourses] = useState<string[]>([]);
 
   useEffect(() => {
     fetch('/api/contributions')
@@ -91,33 +85,15 @@ export function ContributePage() {
 
       {existingCourses.length > 0 && (
         <div className={styles.existingSection}>
-          <button
-            type="button"
-            className={styles.existingToggle}
-            onClick={() => setShowExisting(!showExisting)}
-          >
-            {showExisting ? (
-              <>
-                Hide existing contributions
-                <ChevronUp size={16} />
-              </>
-            ) : (
-              <>
-                Existing contributions: {existingCourses.map((c) => c.code).join(', ')}...
-                <ChevronDown size={16} />
-              </>
-            )}
-          </button>
-          {showExisting && (
-            <ul className={styles.existingList}>
-              {existingCourses.map((course) => (
-                <li key={course.code}>
-                  <strong>{course.code}</strong>
-                  {course.name && ` - ${course.name}`}
-                </li>
-              ))}
-            </ul>
-          )}
+          <p className={styles.existingLabel}>Existing contributions:</p>
+          <p className={styles.existingHint}>
+            These courses have been submitted and will be added to Content Upgrading soon.
+          </p>
+          <ul className={styles.existingList}>
+            {existingCourses.map((course) => (
+              <li key={course}>{course}</li>
+            ))}
+          </ul>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Show full course titles as a plain list (no expand/collapse)
- Add hint text: "These courses have been submitted and will be added to Content Upgrading soon."
- Simplified API to just return course titles as string array

## Test plan
- [ ] Visit /contribute page
- [ ] Verify existing contributions shows full course titles
- [ ] Verify hint text appears below the label