### PR TITLE
v1.5.16: Fix QUE502 missing from upgrading courses list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**v1.5.16 (29 Dec 2025)**
+- Fix QUE502 not appearing in upgrading courses list (missing index export)
+
 **v1.5.15 (29 Dec 2025)**
 - Add QUE502 (Tutorial) upgrading course with 6 tutorial groups
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.5.15",
+  "version": "1.5.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/upgrading-courses/index.ts
+++ b/src/data/upgrading-courses/index.ts
@@ -34,6 +34,12 @@ import QUC501 from './QUC501.json';
 import QUC509 from './QUC509.json';
 
 // QUE - English Language
+import QUE502_G1 from './QUE502-G1.json';
+import QUE502_G2 from './QUE502-G2.json';
+import QUE502_G3 from './QUE502-G3.json';
+import QUE502_G4 from './QUE502-G4.json';
+import QUE502_G5 from './QUE502-G5.json';
+import QUE502_G6 from './QUE502-G6.json';
 import QUE512_G1 from './QUE512-G1.json';
 import QUE512_G2 from './QUE512-G2.json';
 import QUE512_G3 from './QUE512-G3.json';
@@ -87,6 +93,12 @@ export const UPGRADING_COURSES: UpgradingCourse[] = [
   QUC501,
   QUC509,
   // QUE - English Language
+  QUE502_G1,
+  QUE502_G2,
+  QUE502_G3,
+  QUE502_G4,
+  QUE502_G5,
+  QUE502_G6,
   QUE512_G1,
   QUE512_G2,
   QUE512_G3,


### PR DESCRIPTION
## Summary
- Add QUE502-G1 through G6 imports to index.ts
- Add QUE502 groups to UPGRADING_COURSES export array

## Test plan
- [ ] Verify QUE502 groups now appear in upgrading courses dropdown