### PR TITLE
v1.6.1: Add set primary timetable feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**v1.6.1 (5 Jan 2026)**
+- Add ability to set any timetable as your main timetable (star icon in Options → Timetables)
+
 **v1.6.0 (4 Jan 2026)**
 - Add timetable modification support:
   - Edit venue for any event (imported or custom)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/OptionsPanel.module.scss
+++ b/src/components/OptionsPanel.module.scss
@@ -615,6 +615,24 @@
   }
 }
 
+.timetableActionBtnPrimary {
+  color: #d4a017;
+
+  &:hover {
+    background: rgba(212, 160, 23, 0.1);
+    color: #b8860b;
+  }
+
+  html.dark & {
+    color: #f4c430;
+
+    &:hover {
+      background: rgba(244, 196, 48, 0.15);
+      color: #ffd700;
+    }
+  }
+}
+
 .timetableEditRow {
   display: flex;
   align-items: center;

--- a/src/components/OptionsPanel.tsx
+++ b/src/components/OptionsPanel.tsx
@@ -19,6 +19,7 @@ interface OptionsPanelProps {
   timetables: Timetable[];
   activeTimetableId: string | null;
   onSetActiveTimetable: (id: string) => void;
+  onSetPrimaryTimetable: (id: string) => void;
   onAddTimetable: (
     events: TimetableEvent[],
     fileName: string | null,
@@ -47,6 +48,7 @@ export function OptionsPanel({
   timetables,
   activeTimetableId,
   onSetActiveTimetable,
+  onSetPrimaryTimetable,
   onAddTimetable,
   onAddCustomEventsToTimetable,
   onRenameTimetable,
@@ -86,6 +88,7 @@ export function OptionsPanel({
             timetables={timetables}
             activeTimetableId={activeTimetableId}
             onSetActiveTimetable={onSetActiveTimetable}
+            onSetPrimaryTimetable={onSetPrimaryTimetable}
             onAddTimetable={onAddTimetable}
             onAddCustomEventsToTimetable={onAddCustomEventsToTimetable}
             onRenameTimetable={onRenameTimetable}

--- a/src/components/options/TimetableManager.tsx
+++ b/src/components/options/TimetableManager.tsx
@@ -1,4 +1,4 @@
-import { Check, Eye, Link, Pencil, RefreshCw, Trash2, Upload } from 'lucide-react';
+import { Check, Eye, Link, Pencil, RefreshCw, Star, Trash2, Upload } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type {
@@ -37,6 +37,7 @@ interface TimetableManagerProps {
   timetables: Timetable[];
   activeTimetableId: string | null;
   onSetActiveTimetable: (id: string) => void;
+  onSetPrimaryTimetable: (id: string) => void;
   onAddTimetable: (
     events: TimetableEvent[],
     fileName: string | null,
@@ -60,6 +61,7 @@ export function TimetableManager({
   timetables,
   activeTimetableId,
   onSetActiveTimetable,
+  onSetPrimaryTimetable,
   onAddTimetable,
   onAddCustomEventsToTimetable,
   onRenameTimetable,
@@ -249,6 +251,11 @@ export function TimetableManager({
     onViewingToast(name);
   };
 
+  const handleSetPrimaryTimetable = (id: string, name: string) => {
+    onSetPrimaryTimetable(id);
+    setTimetableToast({ message: `"${name}" is now your main timetable.`, type: 'success' });
+  };
+
   return (
     <>
       <div className={styles.section}>
@@ -316,6 +323,15 @@ export function TimetableManager({
                           title="View this timetable"
                         >
                           <Eye size={14} />
+                        </button>
+                      )}
+                      {!timetable.isPrimary && (
+                        <button
+                          className={`${styles.timetableActionBtn} ${styles.timetableActionBtnPrimary}`}
+                          onClick={() => handleSetPrimaryTimetable(timetable.id, timetable.name)}
+                          title="Set as your main timetable"
+                        >
+                          <Star size={14} />
                         </button>
                       )}
                       {timetable.isPrimary && onRegenerateTimetable && (

--- a/src/hooks/useTimetableStorage.ts
+++ b/src/hooks/useTimetableStorage.ts
@@ -277,6 +277,25 @@ export function useTimetableStorage() {
     [setActiveTimetableIdState]
   );
 
+  /**
+   * Sets a timetable as the primary (main) timetable.
+   * Removes primary status from all other timetables.
+   */
+  const setPrimaryTimetable = useCallback((id: string) => {
+    setTimetablesState((prev) => {
+      const timetable = prev.find((t) => t.id === id);
+      if (!timetable || timetable.isPrimary) {
+        return prev;
+      }
+      const updated = prev.map((t) => ({
+        ...t,
+        isPrimary: t.id === id,
+      }));
+      saveTimetables(updated);
+      return updated;
+    });
+  }, []);
+
   /** Gets a timetable by ID */
   const getTimetable = useCallback(
     (id: string): Timetable | null => {
@@ -302,6 +321,7 @@ export function useTimetableStorage() {
     primaryTimetable,
     activeTimetable,
     setActiveTimetable,
+    setPrimaryTimetable,
     addTimetable,
     renameTimetable,
     deleteTimetable,

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -70,6 +70,7 @@ function MainPage() {
     timetables,
     activeTimetable,
     setActiveTimetable,
+    setPrimaryTimetable,
     addTimetable,
     renameTimetable,
     deleteTimetable,
@@ -892,6 +893,7 @@ function MainPage() {
           timetables={timetables}
           activeTimetableId={activeTimetable?.id || null}
           onSetActiveTimetable={setActiveTimetable}
+          onSetPrimaryTimetable={setPrimaryTimetable}
           onAddTimetable={addTimetable}
           onAddCustomEventsToTimetable={addCustomEventToTimetable}
           onRenameTimetable={renameTimetable}


### PR DESCRIPTION
## Summary
- Add `setPrimaryTimetable` function to useTimetableStorage hook
- Add star button in Options → Timetables to set any timetable as your main ("You") timetable
- Show gold star icon for non-primary timetables that can be promoted

## Test plan
- [ ] Add a second timetable via share link or file upload
- [ ] Click the star icon on the second timetable
- [ ] Verify the "You" badge moves to the newly promoted timetable
- [ ] Verify toast appears confirming the change