### PR TITLE
feat: Add cohort-wide events feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v1.7.0 (8 Jan 2026)
+- Add cohort-wide events feature:
+  - Events defined in `src/data/cohort-events.json` appear for all users
+  - Displayed with orange "Cohort" tag
+  - Users can edit or delete cohort events like custom events
+  - Changes are per-user (stored in localStorage)
+
 **v1.6.1 (5 Jan 2026)**
 - Add ability to set any timetable as your main timetable (star icon in Options → Timetables)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/EventCard.module.scss
+++ b/src/components/EventCard.module.scss
@@ -50,6 +50,10 @@
   @include custom-event-style(var(--color-upgrading-border), var(--color-upgrading-bg));
 }
 
+.eventCohort {
+  @include custom-event-style(var(--color-cohort-border), var(--color-cohort-bg));
+}
+
 .eventEdited {
   @include custom-event-style(
     var(--color-edited-border, #f39c12),

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -29,20 +29,22 @@ export const EventCard = memo(function EventCard({
 }: EventCardProps) {
   const isClickable = !!onCourseClick;
   const isCustom = 'isCustom' in event && event.isCustom;
-  const isUpgrading = isCustom && 'eventType' in event && event.eventType === 'upgrading';
+  const eventType = 'eventType' in event ? event.eventType : undefined;
+  const isUpgrading = isCustom && eventType === 'upgrading';
+  const isCohort = isCustom && eventType === 'cohort';
   const isEdited = 'isEdited' in event && event.isEdited;
   const originalVenue = 'originalVenue' in event ? event.originalVenue : undefined;
   const originalTutor = 'originalTutor' in event ? event.originalTutor : undefined;
   const originalStartTime = 'originalStartTime' in event ? event.originalStartTime : undefined;
   const originalEndTime = 'originalEndTime' in event ? event.originalEndTime : undefined;
-  const courseLabel = isUpgrading ? 'Upgrading' : isCustom ? 'Custom' : event.course;
+  const courseLabel = isCohort ? 'Cohort' : isUpgrading ? 'Upgrading' : isCustom ? 'Custom' : event.course;
   const hasTimeEdit = originalStartTime || originalEndTime;
 
   const classNames = [
     styles.eventItem,
     isHighlighted ? styles.eventHighlighted : '',
     !disableCustomStyling &&
-      (isUpgrading ? styles.eventUpgrading : isCustom ? styles.eventCustom : ''),
+      (isCohort ? styles.eventCohort : isUpgrading ? styles.eventUpgrading : isCustom ? styles.eventCustom : ''),
     isEdited ? styles.eventEdited : '',
   ]
     .filter(Boolean)

--- a/src/data/cohort-events.json
+++ b/src/data/cohort-events.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "events": []
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useCohortEvents } from './useCohortEvents';
 export { useCourseColorMap } from './useCourseColorMap';
 export { toCustomEventInput, useCustomEvents } from './useCustomEvents';
 export { useDebouncedValue } from './useDebouncedValue';

--- a/src/hooks/useCohortEvents.ts
+++ b/src/hooks/useCohortEvents.ts
@@ -1,0 +1,133 @@
+import { useEffect, useRef } from 'react';
+
+import cohortEventsData from '../data/cohort-events.json';
+import type { CohortEventDefinition, CohortEventsData, CustomEventType } from '../types';
+import { STORAGE_KEYS } from '../utils/constants';
+import { logError } from '../utils/errors';
+import type { CustomEventInput } from './useCustomEvents';
+
+/**
+ * Storage format for tracking synced cohort events per timetable.
+ */
+interface SyncedCohortEventsStore {
+  [timetableId: string]: string[]; // Array of synced cohort event IDs
+}
+
+/**
+ * Loads synced cohort events from localStorage.
+ */
+function loadSyncedCohortEvents(): SyncedCohortEventsStore {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.SYNCED_COHORT_EVENTS);
+    if (stored) {
+      const data = JSON.parse(stored);
+      if (typeof data === 'object' && data !== null) {
+        return data;
+      }
+    }
+  } catch (e) {
+    logError('useCohortEvents:loadSyncedCohortEvents', e);
+  }
+  return {};
+}
+
+/**
+ * Saves synced cohort events to localStorage.
+ */
+function saveSyncedCohortEvents(store: SyncedCohortEventsStore): void {
+  const hasAnyEvents = Object.values(store).some((ids) => ids.length > 0);
+  if (hasAnyEvents) {
+    localStorage.setItem(STORAGE_KEYS.SYNCED_COHORT_EVENTS, JSON.stringify(store));
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.SYNCED_COHORT_EVENTS);
+  }
+}
+
+/**
+ * Converts a cohort event definition to a custom event input.
+ */
+function cohortEventToCustomEventInput(event: CohortEventDefinition): CustomEventInput {
+  // Convert HH:MM to HHMM format
+  const startTime = event.startTime.replace(':', '');
+  const endTime = event.endTime.replace(':', '');
+
+  // Get day of week from date
+  const date = new Date(event.date);
+  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const day = days[date.getDay()];
+
+  return {
+    course: '', // Will show "Cohort" badge instead
+    group: 'Cohort',
+    day,
+    startTime,
+    endTime,
+    dates: [event.date],
+    venue: event.venue || '',
+    tutor: event.notes || '',
+    eventType: 'cohort' as CustomEventType,
+    description: event.title,
+    groupId: `cohort-${event.id}`, // Use cohort- prefix to identify cohort events
+  };
+}
+
+/**
+ * Hook that syncs cohort events from the JSON file to custom events.
+ *
+ * When a timetable is active:
+ * 1. Checks which cohort events haven't been synced yet
+ * 2. Adds missing events as custom events
+ * 3. Tracks synced events so they don't get re-added
+ *
+ * Users can edit/delete these events like any custom event.
+ * Deleted events won't be re-added (tracked by ID).
+ *
+ * @param activeTimetableId - The ID of the currently active timetable
+ * @param addCustomEvent - Function to add custom events
+ */
+export function useCohortEvents(
+  activeTimetableId: string | null,
+  addCustomEvent: (input: CustomEventInput) => string
+) {
+  // Track if we've already synced for this timetable in this render
+  const syncedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!activeTimetableId) return;
+
+    // Don't sync again if we've already synced for this timetable
+    if (syncedRef.current === activeTimetableId) return;
+
+    const data = cohortEventsData as CohortEventsData;
+    if (!data.events || data.events.length === 0) return;
+
+    // Load synced events
+    const syncedStore = loadSyncedCohortEvents();
+    const syncedIds = syncedStore[activeTimetableId] || [];
+
+    // Find events that haven't been synced
+    const unsyncedEvents = data.events.filter((event) => !syncedIds.includes(event.id));
+
+    if (unsyncedEvents.length === 0) {
+      syncedRef.current = activeTimetableId;
+      return;
+    }
+
+    // Add unsynced events as custom events
+    const newSyncedIds = [...syncedIds];
+    for (const event of unsyncedEvents) {
+      const input = cohortEventToCustomEventInput(event);
+      addCustomEvent(input);
+      newSyncedIds.push(event.id);
+    }
+
+    // Save synced events
+    const updatedStore: SyncedCohortEventsStore = {
+      ...syncedStore,
+      [activeTimetableId]: newSyncedIds,
+    };
+    saveSyncedCohortEvents(updatedStore);
+
+    syncedRef.current = activeTimetableId;
+  }, [activeTimetableId, addCustomEvent]);
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -36,6 +36,7 @@ import {
 import type { UploadSectionHandle } from '../components/UploadSection';
 import {
   toCustomEventInput,
+  useCohortEvents,
   useCustomEvents,
   useDebouncedValue,
   useEventOverrides,
@@ -93,6 +94,9 @@ function MainPage() {
     getCustomEvent,
     getCustomEventsForTimetable,
   } = useCustomEvents(activeTimetable?.id || null);
+
+  // Sync cohort events from JSON file to custom events
+  useCohortEvents(activeTimetable?.id || null, addCustomEvent);
 
   // Event overrides for imported events
   const {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -68,6 +68,12 @@
   --color-upgrading-badge-bg: rgba(22, 160, 133, 0.15);
   --color-upgrading-badge-text: rgba(22, 160, 133, 1);
 
+  // Cohort event styling
+  --color-cohort-border: rgba(230, 126, 34, 1);
+  --color-cohort-bg: rgba(230, 126, 34, 0.08);
+  --color-cohort-badge-bg: rgba(230, 126, 34, 0.15);
+  --color-cohort-badge-text: rgba(211, 84, 0, 1);
+
   // Today highlight
   --color-today: rgba(216, 67, 21, 1);
   --color-today-bg: rgba(100, 108, 255, 0.1);
@@ -170,6 +176,12 @@ html.dark {
   --color-upgrading-bg: rgba(26, 188, 156, 0.15);
   --color-upgrading-badge-bg: rgba(26, 188, 156, 0.25);
   --color-upgrading-badge-text: rgba(26, 188, 156, 1);
+
+  // Cohort event styling (dark)
+  --color-cohort-border: rgba(243, 156, 18, 1);
+  --color-cohort-bg: rgba(243, 156, 18, 0.15);
+  --color-cohort-badge-bg: rgba(243, 156, 18, 0.25);
+  --color-cohort-badge-text: rgba(243, 156, 18, 1);
 
   --color-overlay: rgba(0, 0, 0, 0.7);
   --color-modal-bg: rgba(42, 42, 42, 1);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,7 +156,7 @@ export interface MealConfig {
 /**
  * Type of custom event - determines badge display.
  */
-export type CustomEventType = 'custom' | 'upgrading';
+export type CustomEventType = 'custom' | 'upgrading' | 'cohort';
 
 /**
  * A custom event created by the user (not parsed from NIE).
@@ -379,4 +379,38 @@ export function applyOverridesToEvents(
   }
 
   return result;
+}
+
+// =============================================================================
+// Cohort Event Types
+// =============================================================================
+
+/**
+ * A single cohort event defined in the JSON file.
+ */
+export interface CohortEventDefinition {
+  /** Unique identifier for this cohort event (used to track synced events) */
+  id: string;
+  /** Event title/description */
+  title: string;
+  /** Date in YYYY-MM-DD format */
+  date: string;
+  /** Start time in HH:MM format (24-hour) */
+  startTime: string;
+  /** End time in HH:MM format (24-hour) */
+  endTime: string;
+  /** Venue/location (optional) */
+  venue?: string;
+  /** Additional notes (optional) */
+  notes?: string;
+}
+
+/**
+ * Schema for the cohort-events.json file.
+ */
+export interface CohortEventsData {
+  /** Schema version for future migrations */
+  version: number;
+  /** Array of cohort events */
+  events: CohortEventDefinition[];
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const STORAGE_KEYS = {
   CUSTOM_BACKGROUND: 'nie-custom-background',
   CUSTOM_EVENTS: 'nie-custom-events', // CustomEventsStore JSON
   EVENT_OVERRIDES: 'nie-event-overrides', // EventOverridesStore JSON
+  SYNCED_COHORT_EVENTS: 'nie-synced-cohort-events', // Per-timetable synced cohort event IDs
 } as const;
 
 // Default name sequence for added timetables
@@ -34,6 +35,7 @@ export const DEFAULT_TIMETABLE_NAMES = [
 export const CUSTOM_EVENT_COLORS: Record<string, string> = {
   Custom: '#9c27b0', // Purple
   Upgrading: '#16a085', // Teal
+  Cohort: '#e67e22', // Orange
 } as const;
 
 // Color palette for course codes (rainbow spectrum)


### PR DESCRIPTION
## Summary
- Add cohort-wide events feature where events in `src/data/cohort-events.json` appear for all users
- Events display with orange "Cohort" tag
- Users can edit/delete cohort events like custom events (changes stored per-user in localStorage)

## Test plan
- [ ] Add an event to `src/data/cohort-events.json` with valid date, startTime, endTime
- [ ] Load a timetable and verify the cohort event appears
- [ ] Verify the event has an orange "Cohort" tag
- [ ] Try editing the cohort event (should work like custom events)
- [ ] Try deleting the cohort event (should work like custom events)
- [ ] Refresh the page - deleted event should stay deleted (not re-added)