### PR TITLE
chore: bump version to 1.7.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**v1.7.4 (19 May 2026)**
+- Update dependencies (postcss, vite, protobufjs and related packages)
+
 **v1.7.3 (4 Apr 2026)**
 - Fix minimatch ReDoS security vulnerability (bump eslint 9.39.2 → 9.39.4, @vercel/node 5.6.7 → 5.7.0)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.7.3",
+  "version": "1.7.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Dependency updates since v1.7.3:
- postcss 8.5.6 → 8.5.14
- vite 7.3.0 → 7.3.3
- protobufjs 7.5.4 → 7.6.0
- related protobufjs utilities