### PR TITLE
feat(data): add QCQ52D upgrading course, archive last semester's courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**v1.8.3 (2 Aug 2026)**
+- Add QCQ52D (Further Topics in Computer Applications — Python Upgrading) content upgrading course
+- Archive last semester's content upgrading courses so the course picker only offers courses that are currently running
+
 **v1.8.2 (23 Jul 2026)**
 - Patch dependency security advisories (protobufjs and related packages); production dependency tree is now free of known vulnerabilities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nicer-tt",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nicer-tt",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "dependencies": {
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.8.2",
+  "version": "1.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/upgrading-courses/LLM_INSTRUCTIONS.md
+++ b/src/data/upgrading-courses/LLM_INSTRUCTIONS.md
@@ -74,6 +74,17 @@ For a course "Introduction to Educational Psychology" (ABC1234) with 3 sessions:
 4. Add to array: `export const UPGRADING_COURSES: UpgradingCourse[] = [NewCourse, ...];`
 5. Rebuild the app
 
+## Archiving Past Semesters
+
+`index.ts` exports two arrays. `UPGRADING_COURSES` holds the courses currently on
+offer — this is what the in-app course picker shows. `ARCHIVED_UPGRADING_COURSES`
+holds past-semester courses, which stay in the repo for reference but are not
+offered to users.
+
+At the start of each semester, move the previous semester's entries from
+`UPGRADING_COURSES` into `ARCHIVED_UPGRADING_COURSES` (keep the imports and the
+JSON files). Move a course back if it runs again.
+
 ## Notes
 
 - Date format must be DD/MM (day/month), not MM/DD

--- a/src/data/upgrading-courses/QCQ52D.json
+++ b/src/data/upgrading-courses/QCQ52D.json
@@ -1,0 +1,10 @@
+{
+  "courseName": "QCQ52D - Further Topics in Computer Applications (Python Upgrading)",
+  "sessions": [
+    { "date": "03/08", "startTime": "10:30", "endTime": "12:30", "venue": "NIE2-01-TR201", "tutor": "" },
+    { "date": "17/08", "startTime": "10:30", "endTime": "12:30", "venue": "NIE2-01-TR202", "tutor": "" },
+    { "date": "24/08", "startTime": "10:30", "endTime": "12:30", "venue": "NIE2-01-TR202", "tutor": "" },
+    { "date": "31/08", "startTime": "10:30", "endTime": "12:30", "venue": "NIE2-01-TR202", "tutor": "" },
+    { "date": "07/09", "startTime": "11:30", "endTime": "13:30", "venue": "", "tutor": "" }
+  ]
+}

--- a/src/data/upgrading-courses/index.ts
+++ b/src/data/upgrading-courses/index.ts
@@ -8,6 +8,10 @@
  * 1. Create a new JSON file following the UpgradingCourse schema
  * 2. Import it below and add to the UPGRADING_COURSES array
  *
+ * At the start of each semester, move the previous semester's courses from
+ * UPGRADING_COURSES to ARCHIVED_UPGRADING_COURSES. Archived courses stay in the
+ * repo for reference but are no longer offered in the course picker.
+ *
  * JSON Schema:
  * {
  *   "courseName": "ABC1234 - Full Course Name",
@@ -24,6 +28,8 @@
  */
 
 import type { UpgradingCourse } from '../../types';
+// QCQ - Computer Applications
+import QCQ52D from './QCQ52D.json';
 // QUB - Biology
 import QUB511 from './QUB511.json';
 import QUB513 from './QUB513.json';
@@ -78,10 +84,21 @@ import QUY511 from './QUY511.json';
 import QUY512 from './QUY512.json';
 
 /**
- * All available upgrading courses.
+ * Upgrading courses currently on offer — these are what the course picker shows.
  * Add new courses here after importing their JSON files.
  */
 export const UPGRADING_COURSES: UpgradingCourse[] = [
+  // QCQ - Computer Applications
+  QCQ52D,
+];
+
+/**
+ * Past-semester upgrading courses, kept for reference only.
+ * These are not offered in the course picker. Move a course back into
+ * UPGRADING_COURSES if it runs again.
+ */
+export const ARCHIVED_UPGRADING_COURSES: UpgradingCourse[] = [
+  // Semester 2, AY2025/26 (Jan-Feb 2026)
   // QUB - Biology
   QUB511,
   QUB513,


### PR DESCRIPTION
Closes #143

## What

**Adds QCQ52D** — Further Topics in Computer Applications (Python Upgrading), from the contribution-form submission in #143:

| Date | Time | Venue |
|---|---|---|
| 03/08 | 10:30–12:30 | NIE2-01-TR201 |
| 17/08 | 10:30–12:30 | NIE2-01-TR202 |
| 24/08 | 10:30–12:30 | NIE2-01-TR202 |
| 31/08 | 10:30–12:30 | NIE2-01-TR202 |
| 07/09 | 11:30–13:30 | *(TBA)* — G3 Computing Proficiency Test |

Tutor was not given in the submission, so it is `""` throughout. `TR 201` / `TR202` were expanded to the `NIE2-01-TR2xx` form used everywhere else in the data.

**Archives last semester's courses.** `index.ts` now exports two arrays:

- `UPGRADING_COURSES` — currently on offer; this is what the course picker renders
- `ARCHIVED_UPGRADING_COURSES` — past semesters, kept in the repo for reference

Every pre-existing course ran in Jan–Feb 2026 (Semester 2, AY2025/26), so all of them moved to the archive. The picker now offers only QCQ52D. No JSON files were deleted, and existing user timetables are unaffected — the array only feeds the "add course" picker.

Documented the per-semester archiving step in `LLM_INSTRUCTIONS.md`.

## Verification

- `npm run build` — passes
- `npm run lint` — clean
- `npx vitest run` — 14/14 pass
- Bundle drops 683 kB → 657 kB, since the archived JSON is no longer reachable and tree-shakes out

Version bumped to 1.8.3 with a changelog entry.
