### PR TITLE
fix: stop upgrading sessions dated today from rolling forward a year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-**v1.8.3 (2 Aug 2026)**
+**v1.8.4 (3 Aug 2026)**
+- Fix content upgrading sessions falling on today being dated a year late — a session on 3 Aug showed as "Tue, Aug 3" (2027) instead of "Mon, Aug 3" (2026), and was added to the timetable with the wrong year
+
+**v1.8.3 (3 Aug 2026)**
 - Add QCQ52D (Further Topics in Computer Applications — Python Upgrading) content upgrading course
 - Archive last semester's content upgrading courses so the course picker only offers courses that are currently running
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nicer-tt",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nicer-tt",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dependencies": {
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nicer-tt",
   "private": true,
-  "version": "1.8.3",
+  "version": "1.8.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/AddEventModal/utils.test.ts
+++ b/src/components/AddEventModal/utils.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dateToIso, ddmmToDate, formatPreviewDate } from './utils';
+
+/**
+ * Upgrading course sessions are stored as bare `DD/MM` with no year, so
+ * `ddmmToDate` has to infer one: this year if the date is still ahead, next year
+ * if it has already passed.
+ *
+ * The boundary that matters is TODAY. `ddmmToDate` builds the candidate date at
+ * midnight, so comparing it against the current instant (rather than the start of
+ * today) makes a session happening today look like it is in the past from 00:00
+ * onwards — and rolls it a full year forward. That shifted the weekday too, which
+ * is how it surfaced: "03/08" rendered as "Tue, Aug 3" (2027) sitting above
+ * "Mon, Aug 17" (2026), two dates 14 days apart claiming different weekdays.
+ *
+ * "Now" is pinned so the suite is deterministic regardless of when it runs.
+ * NB: Date months are 0-indexed, so 7 === August.
+ */
+
+const LATE_ON_3_AUG_2026 = new Date(2026, 7, 3, 23, 53, 0);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(LATE_ON_3_AUG_2026);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ddmmToDate', () => {
+  it('keeps a session dated today in the current year, even late in the day', () => {
+    expect(dateToIso(ddmmToDate('03/08'))).toBe('2026-08-03');
+  });
+
+  it('keeps a session dated today in the current year at one second to midnight', () => {
+    vi.setSystemTime(new Date(2026, 7, 3, 23, 59, 59));
+    expect(dateToIso(ddmmToDate('03/08'))).toBe('2026-08-03');
+  });
+
+  it('keeps a future date in the current year', () => {
+    expect(dateToIso(ddmmToDate('17/08'))).toBe('2026-08-17');
+  });
+
+  it('rolls a genuinely past date forward to next year', () => {
+    expect(dateToIso(ddmmToDate('02/08'))).toBe('2027-08-02');
+  });
+
+  it('rolls a date earlier in the year forward to next year', () => {
+    expect(dateToIso(ddmmToDate('15/01'))).toBe('2027-01-15');
+  });
+
+  it('resolves consecutive fortnightly sessions to the same weekday', () => {
+    const first = ddmmToDate('03/08');
+    const second = ddmmToDate('17/08');
+    expect(first.getDay()).toBe(second.getDay());
+  });
+});
+
+describe('formatPreviewDate', () => {
+  it('labels 3 Aug 2026 as a Monday', () => {
+    expect(formatPreviewDate('03/08')).toBe('Mon, Aug 3');
+  });
+
+  it('labels the rest of the QCQ52D sessions as Mondays', () => {
+    expect(formatPreviewDate('17/08')).toBe('Mon, Aug 17');
+    expect(formatPreviewDate('24/08')).toBe('Mon, Aug 24');
+    expect(formatPreviewDate('31/08')).toBe('Mon, Aug 31');
+    expect(formatPreviewDate('07/09')).toBe('Mon, Sep 7');
+  });
+});

--- a/src/components/AddEventModal/utils.ts
+++ b/src/components/AddEventModal/utils.ts
@@ -40,8 +40,12 @@ export function ddmmToDate(ddmm: string): Date {
   const [day, month] = ddmm.split('/').map(Number);
   const now = new Date();
   const thisYear = new Date(now.getFullYear(), month - 1, day);
+  // Compare against the start of today, not the current instant. `thisYear` is
+  // midnight, so comparing it to `now` would classify a session happening TODAY
+  // as past from 00:00 onwards and roll it a full year forward.
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   // If the date is in the past, use next year
-  if (thisYear < now) {
+  if (thisYear < startOfToday) {
     return new Date(now.getFullYear() + 1, month - 1, day);
   }
   return thisYear;


### PR DESCRIPTION
## The bug

QCQ52D's session list rendered like this:

| | |
|---|---|
| **Tue, Aug 3** | 10:30 AM - 12:30 PM |
| **Mon, Aug 17** | 10:30 AM - 12:30 PM |

Those two dates are 14 days apart, so they must be the same weekday. 3 Aug 2026 is a Monday.

## Cause

`ddmmToDate` in `src/components/AddEventModal/utils.ts` resolves a bare `DD/MM` to a year — this year if the date is still ahead, next year if it has passed. It built the candidate at **midnight** and compared it against **`now`**:

```ts
const thisYear = new Date(now.getFullYear(), month - 1, day);
if (thisYear < now) {
  return new Date(now.getFullYear() + 1, month - 1, day);
}
```

From 00:00:01 onward, a session dated *today* is "earlier than now" and gets pushed a **full year** forward. `03/08` became 3 Aug **2027** — a Tuesday. Later sessions were genuinely in the future, stayed in 2026, and rendered as Mondays.

## Impact

Not just the label. `AddEventModal.tsx:186` uses the same helper to build the events it writes, so adding a course on the day one of its sessions runs stored that session **a year out**, where it would never appear in the user's timetable.

## Fix

Compare against the start of today rather than the current instant.

## Tests

New `src/components/AddEventModal/utils.test.ts` (8 tests), clock pinned to 23:53 on 3 Aug 2026 — the condition under which this reproduces. Verified they fail against the unfixed code:

```
× keeps a session dated today in the current year, even late in the day
× keeps a session dated today in the current year at one second to midnight
× resolves consecutive fortnightly sessions to the same weekday
× labels 3 Aug 2026 as a Monday
  AssertionError: expected 'Tue, Aug 3' to be 'Mon, Aug 3'
```

Covers the today boundary (including 23:59:59), genuinely past dates still rolling forward correctly, and the QCQ52D weekday labels.

## Verification

`npm run build` passes, `npm run lint` clean, `npx vitest run` 22/22.

Version bumped to 1.8.4. Also corrects the v1.8.3 changelog date to 3 Aug.
